### PR TITLE
Remove link to AdoptOpenJDK status page

### DIFF
--- a/src/handlebars/partials/menu.handlebars
+++ b/src/handlebars/partials/menu.handlebars
@@ -19,7 +19,6 @@
           <li><a href="./members.html">Members</a></li>
           {{!-- <li><a target="_blank" href="https://api.adoptium.net">API</a></li> --}}
           <li><a target="_blank" href="https://blog.adoptium.net/">Blog</a></li>
-          <li><a target="_blank" href="https://status.adoptopenjdk.net/">Status</a></li>
           <li><a href="./supported_platforms.html">Supported Platforms</a></li>
         </ul>
       </li>


### PR DESCRIPTION
Fixes #62
Link will be re-added when it points to the Adoptium status page