### PR TITLE
Add required notice to archive downloads

### DIFF
--- a/src/handlebars/archive.handlebars
+++ b/src/handlebars/archive.handlebars
@@ -6,16 +6,16 @@
     <h1 class="large-title">Archive</h1>
 
     <div class="callout">
-      <p>Please be aware that the archive contains old releases and intermediate builds created as a
-         development step towards a full release.  Using old, superseded, or otherwise unsupported
+      <p>Please be aware that this archive contains old releases and intermediate builds created as a
+         development step towards a full release. Using old, superseded, or otherwise unsupported
          releases is not recommended.</p>
        <!-- Required notice follows. Do not remove or modify. -->
       <p>The following notice applies to intermediate builds:<br/>
          "This is an intermediate build made available for testing purposes only. The code is untested
           and presumed incompatible with the Java SE specification. You should not deploy or write to
           this code, but instead use the tested and certified Java SE compatible version of the code
-          that is available at <a href="https://adoptium.net" class='light-link'>adoptium.net</a>.
-          Redistribution of any Intermediate Build must retain this notice."</p>
+          that is available at <a href="https://adoptium.net/releases.html">adoptium.net</a>. Redistribution
+          of any Intermediate Build must retain this notice."</p>
     </div>
 
     <a href="./releases.html" id="latest-button" class="blue-button a-button">

--- a/src/handlebars/archive.handlebars
+++ b/src/handlebars/archive.handlebars
@@ -6,7 +6,16 @@
     <h1 class="large-title">Archive</h1>
 
     <div class="callout">
-      <p>Please be aware that using old, superseded, or otherwise unsupported releases is not recommended.</p>
+      <p>Please be aware that the archive contains old releases and intermediate builds created as a
+         development step towards a full release.  Using old, superseded, or otherwise unsupported
+         releases is not recommended.</p>
+       <!-- Required notice follows. Do not remove or modify. -->
+      <p>The following notice applies to intermediate builds:<br/>
+         "This is an intermediate build made available for testing purposes only. The code is untested
+          and presumed incompatible with the Java SE specification. You should not deploy or write to
+          this code, but instead use the tested and certified Java SE compatible version of the code
+          that is available at <a href="https://adoptium.net" class='light-link'>adoptium.net</a>.
+          Redistribution of any Intermediate Build must retain this notice."</p>
     </div>
 
     <a href="./releases.html" id="latest-button" class="blue-button a-button">


### PR DESCRIPTION
Notice applies to non-JCK'd builds and is displayed in such a manner that anyone downloading an Intermediate Build must see the notice before commencing the download.

Part of https://github.com/adoptium/adoptium/issues/18