### PR TITLE
Updating supported platforms

### DIFF
--- a/src/handlebars/supported_platforms.handlebars
+++ b/src/handlebars/supported_platforms.handlebars
@@ -129,8 +129,7 @@
 
         <br/>
 
-        {{!-- <p><strong>Note:</strong> Any other Linux distributions that have a minimum glibc version 2.12 on x86, 2.23 on aarch32 and 2.17 on other architectures are expected to function without problems.</p>
-        --}}
+        <p><strong>Note:</strong> Any other Linux distributions that have a minimum glibc version 2.12 on x86, 2.23 on aarch32 and 2.17 on other architectures are expected to function without problems.</p>
         <table>
             <thead>
                 <tr>
@@ -864,7 +863,7 @@
       </table> --}}
 
 
-  <h3 id="openjdk11_platforms">Temurin 16</h3>
+  <h3 id="openjdk16_platforms">Temurin 16</h3>
 
         <p>Where available, binaries are supported on the minimum operating system levels shown in the following tables:</p>
 

--- a/src/handlebars/supported_platforms.handlebars
+++ b/src/handlebars/supported_platforms.handlebars
@@ -863,19 +863,7 @@
             <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
           </tr>
         </tbody>
-      </table>
-
-    </div>
-
-    <div style="margin-top: 3rem;">
-      <a href="./support.html" class="no-underline home-links">
-        <h2 class="inline-block zero-margin">Support&nbsp;<i class="fa fa-arrow-circle-o-right" aria-hidden="true"></i></h2>
-      </a>
-      <a href="https://github.com/adoptium/adoptium-support/issues" class="no-underline home-links">
-        <h2 class="inline-block zero-margin">Submit an Issue&nbsp;<i class="fa fa-arrow-circle-o-right" aria-hidden="true"></i></h2>
-      </a>
-    </div>
-  </div> --}}
+      </table> --}}
 
 
   <h3 id="openjdk11_platforms">Temurin 16</h3>
@@ -1067,8 +1055,17 @@
             </tbody>
         </table>
 
-        <br/>
+    </div>
 
+    <div style="margin-top: 3rem;">
+      <a href="./support.html" class="no-underline home-links">
+        <h2 class="inline-block zero-margin">Support&nbsp;<i class="fa fa-arrow-circle-o-right" aria-hidden="true"></i></h2>
+      </a>
+      <a href="https://github.com/adoptium/adoptium-support/issues" class="no-underline home-links">
+        <h2 class="inline-block zero-margin">Submit an Issue&nbsp;<i class="fa fa-arrow-circle-o-right" aria-hidden="true"></i></h2>
+      </a>
+    </div>
+  </div>
 </main>
 
 {{> footer }}

--- a/src/handlebars/supported_platforms.handlebars
+++ b/src/handlebars/supported_platforms.handlebars
@@ -8,15 +8,15 @@
 
   <div class="align-left support">
 
-    <p>We're currently working out our list of supported platforms. Please check back later!</p>
+    {{!-- <p>We're currently working out our list of supported platforms. Please check back later!</p> --}}
 
-    {{!-- <div class="anchor">
+    <div class="anchor">
         <a href="#platform-support-matrix" class="anchor"><img src="dist/assets/anchor.png" alt="anchor icon"></a>
         <h2 class="bold"><a id="platform-support-matrix">Platform Support Matrix</a></h2>
     </div>
     <div class="margin-bottom">
 
-        <h3 id="openjdk8_platforms">Adoptium 8</h3>
+        <h3 id="openjdk8_platforms">Temurin 8</h3>
         <p>Where available, binaries are supported on the minimum operating system levels shown in the following tables:</p>
 
         <table>
@@ -41,143 +41,145 @@
                 <tr>
                     <th>Linux</th>
                     <th>x64</th>
-                    <th>ppc64le</th>
+                    {{!-- <th>ppc64le</th>
                     <th>s390x</th>
                     <th>aarch32</th>
-                    <th>aarch64</th>
+                    <th>aarch64</th> --}}
                 </tr>
             </thead>
             <tbody>
                 <tr>
                     <td>Centos 6.9</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td></td>
                     <td></td>
                     <td></td>
-                    <td></td>
-                    <td></td>
+                    <td></td> --}}
                 </tr>
                 <tr>
                     <td>Centos 7.4</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                     <td>Centos 8</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                     <td>Red Hat Enterprise Linux (RHEL) 6.9</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td></td>
                     <td></td>
                     <td></td>
-                    <td></td>
-                    <td></td>
+                    <td></td> --}}
                 </tr>
                 <tr>
                     <td>RHEL 7.4</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                     <td>RHEL 8</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                     <td>SUSE Linux Enterprise Server (SLES) 12</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td></td>
-                    <td></td>
+                    <td></td> --}}
                 </tr>
                 <tr>
                     <td>Ubuntu 16.04</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                     <td>Ubuntu 18.04</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                   <td>Ubuntu 20.04</td>
                   <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                  {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                   <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                   <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                  <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                  <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                  <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
             </tbody>
         </table>
 
-        <p><strong>Note:</strong> Any other Linux distributions that have a minimum glibc version 2.12 on x86, 2.23 on aarch32 and 2.17 on other architectures are expected to function without problems.</p>
+        <br/>
 
+        {{!-- <p><strong>Note:</strong> Any other Linux distributions that have a minimum glibc version 2.12 on x86, 2.23 on aarch32 and 2.17 on other architectures are expected to function without problems.</p>
+        --}}
         <table>
             <thead>
                 <tr>
                     <th>Windows</th>
-                    <th>x32</th>
+                    {{!-- <th>x32</th> --}}
                     <th>x64</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
                     <td>Windows 7 SP1</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows 8</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows 8.1</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows 10</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows Server 2012</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows Server 2012 R2</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows Server 2016</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows Server 2019</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
             </tbody>
@@ -202,7 +204,7 @@
 
         <br/>
 
-        <table>
+        {{!-- <table>
             <thead>
                 <tr>
                     <th>AIX</th>
@@ -242,10 +244,10 @@
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
             </tbody>
-        </table>
+        </table> --}}
 
 
-        <h3 id="openjdk11_platforms">Adoptium 11</h3>
+        <h3 id="openjdk11_platforms">Temurin 11</h3>
 
         <p>Where available, binaries are supported on the minimum operating system levels shown in the following tables:</p>
 
@@ -271,145 +273,147 @@
                 <tr>
                     <th>Linux</th>
                     <th>x64</th>
-                    <th>ppc64le</th>
+                    {{!-- <th>ppc64le</th>
                     <th>s390x</th>
                     <th>aarch32</th>
-                    <th>aarch64</th>
+                    <th>aarch64</th> --}}
                 </tr>
             </thead>
             <tbody>
                 <tr>
                     <td>Centos 6.9</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td></td>
                     <td></td>
                     <td></td>
-                    <td></td>
-                    <td></td>
+                    <td></td> --}}
                 </tr>
                 <tr>
                     <td>Centos 7.4</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                     <td>Centos 8</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td></td>
                     <td></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                     <td>RHEL 6.9</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td></td>
                     <td></td>
                     <td></td>
-                    <td></td>
-                    <td></td>
+                    <td></td> --}}
                 </tr>
                 <tr>
                     <td>RHEL 7.4</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                     <td>RHEL 8</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                     <td>SLES 12</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td></td>
-                    <td></td>
+                    <td></td> --}}
                 </tr>
                 <tr>
                     <td>Ubuntu 16.04</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                     <td>Ubuntu 18.04</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
                 <tr>
                   <td>Ubuntu 20.04</td>
                   <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                  {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                   <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                   <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                  <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
-                  <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                  <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                 </tr>
             </tbody>
         </table>
 
-        <p><strong>Note:</strong> Any other Linux distributions that have a minimum glibc version 2.12 on x86, 2.23 on aarch32 and 2.17 on other architectures are expected to function without problems.</p>
+        <br/>
 
+        {{!-- <p><strong>Note:</strong> Any other Linux distributions that have a minimum glibc version 2.12 on x86, 2.23 on aarch32 and 2.17 on other architectures are expected to function without problems.</p>
+        --}}
         <table>
             <thead>
                 <tr>
                     <th>Windows</th>
-                    <th>x32</th>
+                    {{!-- <th>x32</th> --}}
                     <th>x64</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
                     <td>Windows 7 SP1</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows 8</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows 8.1</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows 10</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows Server 2012</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows Server 2012 R2</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows Server 2016</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
                     <td>Windows Server 2019</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
             </tbody>
@@ -434,7 +438,7 @@
 
         <br/>
 
-        <table>
+        {{!-- <table>
             <thead>
                 <tr>
                     <th>AIX</th>
@@ -872,6 +876,198 @@
       </a>
     </div>
   </div> --}}
+
+
+  <h3 id="openjdk11_platforms">Temurin 16</h3>
+
+        <p>Where available, binaries are supported on the minimum operating system levels shown in the following tables:</p>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>Key</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>HotSpot VM</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+            </tbody>
+        </table>
+
+        <br/>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>Linux</th>
+                    <th>x64</th>
+                    {{!-- <th>ppc64le</th>
+                    <th>s390x</th>
+                    <th>aarch32</th>
+                    <th>aarch64</th> --}}
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Centos 6.9</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td></td>
+                    <td></td>
+                    <td></td>
+                    <td></td> --}}
+                </tr>
+                <tr>
+                    <td>Centos 7.4</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                </tr>
+                <tr>
+                    <td>Centos 8</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td></td>
+                    <td></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                </tr>
+                <tr>
+                    <td>RHEL 6.9</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td></td>
+                    <td></td>
+                    <td></td>
+                    <td></td> --}}
+                </tr>
+                <tr>
+                    <td>RHEL 7.4</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                </tr>
+                <tr>
+                    <td>RHEL 8</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                </tr>
+                <tr>
+                    <td>SLES 12</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td></td>
+                    <td></td> --}}
+                </tr>
+                <tr>
+                    <td>Ubuntu 16.04</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                </tr>
+                <tr>
+                    <td>Ubuntu 18.04</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                </tr>
+                <tr>
+                  <td>Ubuntu 20.04</td>
+                  <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                  {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                  <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                  <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                  <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                </tr>
+            </tbody>
+        </table>
+
+        <br/>
+
+        {{!-- <p><strong>Note:</strong> Any other Linux distributions that have a minimum glibc version 2.12 on x86, 2.23 on aarch32 and 2.17 on other architectures are expected to function without problems.</p>
+        --}}
+        <table>
+            <thead>
+                <tr>
+                    <th>Windows</th>
+                    {{!-- <th>x32</th> --}}
+                    <th>x64</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Windows 7 SP1</td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>Windows 8</td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>Windows 8.1</td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>Windows 10</td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>Windows Server 2012</td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>Windows Server 2012 R2</td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>Windows Server 2016</td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>Windows Server 2019</td>
+                    {{!-- <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td> --}}
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+            </tbody>
+        </table>
+
+        <br/>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>macOS</th>
+                    <th>x64</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>OSX 10.10+</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+            </tbody>
+        </table>
+
+        <br/>
 
 </main>
 

--- a/src/handlebars/supported_platforms.handlebars
+++ b/src/handlebars/supported_platforms.handlebars
@@ -861,7 +861,8 @@
           </tr>
         </tbody>
       </table> --}}
-
+  
+  <br/>
 
   <h3 id="openjdk16_platforms">Temurin 16</h3>
 

--- a/src/handlebars/supported_platforms.handlebars
+++ b/src/handlebars/supported_platforms.handlebars
@@ -8,8 +8,6 @@
 
   <div class="align-left support">
 
-    {{!-- <p>We're currently working out our list of supported platforms. Please check back later!</p> --}}
-
     <div class="anchor">
         <a href="#platform-support-matrix" class="anchor"><img src="dist/assets/anchor.png" alt="anchor icon"></a>
         <h2 class="bold"><a id="platform-support-matrix">Platform Support Matrix</a></h2>


### PR DESCRIPTION
Updated the information on the "Supported Platforms" page, to include that Temurin 8/11/16 are now available on x64 Linux, x64 Windows and x64 MacOS. Also changed "Adoptium 8/11/16" to "Temurin 8/11/16".

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
