### PR TITLE
remove_linux_install_info

### DIFF
--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -93,13 +93,13 @@
     <h2 id="installers">Installers</h2>
 
     <div class="margin-bottom">
-      <p>Installers are currently available for Windows&reg;, Linux&reg;, and macOS&reg; JDK and JRE packages. Installation steps
+      <p>Installers are currently available for Windows&reg;{{!-- , Linux&reg;, --}} and macOS&reg; JDK and JRE packages. Installation steps
         are covered in the following sections:
       </p>
         <ul>
           <li><a href="#windows-msi">Windows MSI installer packages</a></li>
           <li><a href="#macos-pkg">macOS PKG installer packages</a></li>
-          <li><a href="#linux-pkg">Linux RPM and DEB installer packages</a></li>
+{{!--          <li><a href="#linux-pkg">Linux RPM and DEB installer packages</a></li> --}}
         </ul>
 
     </div>


### PR DESCRIPTION
The section on Linux installers had been commented out, but the reference links to the sections had not, and therefore were visible but didn't work. They should be removed until we have the installers available.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
