### PR TITLE
Change default to OpenJDK 17

### DIFF
--- a/src/json/config.json
+++ b/src/json/config.json
@@ -10,7 +10,6 @@
       "searchableName": "openjdk11",
       "jvm": ["HotSpot"],
       "label": "OpenJDK 11",
-      "default": true,
       "lts": true
     },
     {
@@ -23,6 +22,7 @@
       "searchableName": "openjdk17",
       "jvm": ["HotSpot"],
       "label": "OpenJDK 17",
+      "default": true,
       "lts": true
     }
   ],


### PR DESCRIPTION
Move default selection from OpenJDK 11 to latest LTS, OpenJDK 17

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
