### PR TITLE
Put JRE-equivalent jlink command in the site banner

### DIFF
--- a/src/handlebars/partials/header.handlebars
+++ b/src/handlebars/partials/header.handlebars
@@ -73,7 +73,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Banner Div - This is where you can add banners to the website -->
   <div class="alert align-center">
     <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
-    <strong>22nd Sept 2021</strong> Eclipse Temurin 17 GA initial platforms <a style="color: white"
-    href="https://adoptium.net/releases.html?variant=openjdk17">are available</a>!<br/>
-    You can track progress of <a style="color: white" href="https://github.com/adoptium/adoptium/issues/74">additional platforms</a>.
+    <strong>1st October 2021</strong> Eclipse Temurin 17 GA now available. Missing the v17 JRE? Try taking our JDK and run:<br/>
+    <tt>jdk-17+35/bin/jlink --add-modules ALL-MODULE-PATH --compress=2 --output jre-17+35</tt></a>
   </div>

--- a/src/handlebars/partials/header.handlebars
+++ b/src/handlebars/partials/header.handlebars
@@ -73,6 +73,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Banner Div - This is where you can add banners to the website -->
   <div class="alert align-center">
     <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
-    <strong>1st October 2021</strong> Eclipse Temurin 17 GA now available. Missing the v17 JRE? Try taking our JDK and run:<br/>
+    <strong>1st October 2021</strong> Eclipse Temurin 17 GA now available. Missing the v17 JRE? Try downloading our JDK and run:<br/>
     <tt>jdk-17+35/bin/jlink --add-modules ALL-MODULE-PATH --compress=2 --output jre-17+35</tt></a>
   </div>


### PR DESCRIPTION
Adding all PMC members as reviewers FAO since Slack isn't behaving today due to a DNS TTL issue so it's harder to discuss on there at the moment.

I was thinking that in the short term at least - even if just until we update the banner for the October releases - putting the cut & pastable one liner on the main adoptium page (initially as a banner, maybe somewhere else alongside the downloads later) might be a good idea. I feel it's a bit better than [shipping a new tool](https://github.com/adoptium/temurin-build/pull/2736) with our JDKs  (which pretty much just runs the one liner) which we have to support and would have to carefully consider if we wanted to change the options on it. Plus even if we do ship the tool this would give us a quick way of getting the information directly in front of people on our front page.

The interesting observation on this is that the footprint of disk of a jlink'd version with this comment is smaller thand the "JRE" we used to produce, but the `lib/modules` file does NOT compress as well as the one in the JRE for some reason and so when you tar it up it seems to be larger than the "legacy JRE" package.

_(Side comment: This may also have been an opportunity to promote jlink.online, but that currently seems to be down and only displays an AdoptOpenJDK logo)_

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
