### PR TITLE
Update support page with Java 17 GA and Java 18 dates

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -94,23 +94,34 @@
           <td>Java 16</td>
           <td>Mar 2021</td>
           <td>
-            <strong>16.0.2<br/>
+            16.0.2<br/>
             30th Jul 2021
           </td>
           <td>None</td>
-          <td>N/A</td>
+          <td>Sep 2021</td>
         </tr>
         <tr>
-          <td>Java 17 (LTS)</td>
-          <td>Sep 2021</td>
+          <td><strong>Java 17 (LTS)<strong></td>
+          <td><strong>Sep 2021</strong></td>
           <td>
-            N/A<br/>
+            <strong>jdk-17+35<br/>
+                    14th Sep 2021</strong>
           </td>
           <td>
-            jdk-17<br/>
-            19th Sep 2021
+            jdk-17.0.1<br/>
+            Oct 2021
           </td>
           <td>TBC<sup>[1]</sup></td>
+        </tr>
+        <tr>
+          <td>Java 18</td>
+          <td>Mar 2022</td>
+          <td>N/A</td>
+          <td>
+            jdk-18<br/>
+            15th Mar 2021
+          </td>
+          <td>Sep 2022</td>
         </tr>
 
       </table>


### PR DESCRIPTION
Updates for the support page. Note that on the "previous" site we used to always list the upstream openjdk release dates, but in this table we haven't seemingly been keeping to that as some of the GA dates are later - was that intentional? I'm listing the upstream openjdk source GA dates in these updates.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
