### PR TITLE
Add clarification on front page that Temurin is Adoptium's OpenJDK distribution

### DIFF
--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -4,7 +4,8 @@
   <h1>Prebuilt OpenJDK Binaries for Free!</h1>
   <p class="intro">
     Java™ is the world's leading programming language and platform.
-    The Adoptium Working Group promotes and supports high-quality, TCK certified runtimes and associated technology for use across the Java™ ecosystem.
+    The Adoptium Working Group promotes and supports high-quality, TCK certified runtimes and associated technology for use across the Java™ ecosystem.<br/>
+    <a href="faq.html#temurinName">Eclipse Temurin</a> is the name of the OpenJDK distribution from Adoptium
   </p>
 
   <div class="dl-container">

--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -5,7 +5,7 @@
   <p class="intro">
     Java™ is the world's leading programming language and platform.
     The Adoptium Working Group promotes and supports high-quality, TCK certified runtimes and associated technology for use across the Java™ ecosystem.<br/>
-    <a href="faq.html#temurinName">Eclipse Temurin</a> is the name of the OpenJDK distribution from Adoptium
+    <a href="faq.html#temurinName">Eclipse Temurin</a> is the name of the OpenJDK distribution from Adoptium.
   </p>
 
   <div class="dl-container">


### PR DESCRIPTION
Particularly during this transition period I think this is important to put on the front page. I've included a link to the FAQ.

Interested to see how this previous since for some reason why I click on the new link on my local machine when I render this it tries to initiate a download as well as navigating to the FAQ (!)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
