### PR TITLE
Update JFR and JMC status in migration guide

### DIFF
--- a/src/handlebars/migration.handlebars
+++ b/src/handlebars/migration.handlebars
@@ -88,14 +88,14 @@
           <tr>
             <td>Java Flight Recorder (JFR)</td>
             <td><a href="#java-flight-recorder">Java Flight Recorder</a></td>
-            <td><i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">no</span> (coming soon)</td>
+            <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span></td>
             <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span></td>
           </tr>
           <tr>
             <td>Java Mission Control (JMC)</td>
             <td>Use <a href="#jdk-mission-control">JDK Mission Control</a></td>
-            <td><i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">no</span> (coming soon)</td>
-            <td><i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">no</span> (coming soon)</td>
+            <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span></td>
+            <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
This updates the migration checkboxes for:

JFR to yes for OpenJDK 8, which has been available since 8u262 and enabled since 8u272 (Oct 2020)

JMC to yes for OpenJDK 8 and 11, which has adoptopenjdk builds and builds from other vendors. This follows the precedence for icedtea-web being marked available for 8.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [-] documentation is changed or added (if applicable)
- [-] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
