### PR TITLE
Add page for JDK Mission Control downloads

### DIFF
--- a/src/handlebars/jmc.handlebars
+++ b/src/handlebars/jmc.handlebars
@@ -19,21 +19,21 @@
         <td class="first_col">Windows</td>
         <td>8.1.1</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.1/org.openjdk.jmc-8.1.1-win32.win32.x86_64.zip">org.openjdk.jmc-8.1.1-win32.win32.x86_64.zip</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.1.1/org.openjdk.jmc-8.1.1-win32.win32.x86_64.zip">org.openjdk.jmc-8.1.1-win32.win32.x86_64.zip</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Mac</td>
         <td>8.1.1</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.1/org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.1.1/org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Linux</td>
         <td>8.1.1</td>
        <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.1/org.openjdk.jmc-8.1.1-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.1.1-linux.gtk.x86_64.tar.gz</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.1.1/org.openjdk.jmc-8.1.1-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.1.1-linux.gtk.x86_64.tar.gz</a>
         </td>
       </tr>
     </table>
@@ -51,21 +51,21 @@
         <td class="first_col">Windows</td>
         <td>8.2.0-SNAPSHOT</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-win32.win32.x86_64.zip">org.openjdk.jmc-8.2.0-SNAPSHOT-win32.win32.x86_64.zip</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-win32.win32.x86_64.zip">org.openjdk.jmc-8.2.0-SNAPSHOT-win32.win32.x86_64.zip</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Mac</td>
         <td>8.2.0-SNAPSHOT</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.2.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.2.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Linux</td>
         <td>8.2.0-SNAPSHOT</td>
        <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.2.0-SNAPSHOT-linux.gtk.x86_64.tar.gz</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.2.0-SNAPSHOT-linux.gtk.x86_64.tar.gz</a>
         </td>
       </tr>
     </table>
@@ -85,13 +85,13 @@
       <tr>
         <td>8.1.1</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.1/org.openjdk.jmc.updatesite.ide-8.1.1.zip">org.openjdk.jmc.updatesite.ide-8.1.1.zip</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.1.1/org.openjdk.jmc.updatesite.ide-8.1.1.zip">org.openjdk.jmc.updatesite.ide-8.1.1.zip</a>
         </td>
       </tr>
       <tr>
         <td>8.2.0-SNAPSHOT</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc.updatesite.ide-8.2.0-SNAPSHOT.zip">org.openjdk.jmc.updatesite.ide-8.2.0-SNAPSHOT.zip</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc.updatesite.ide-8.2.0-SNAPSHOT.zip">org.openjdk.jmc.updatesite.ide-8.2.0-SNAPSHOT.zip</a>
         </td>
       </tr>
     </table>
@@ -108,21 +108,21 @@
         <td class="first_col">Windows</td>
         <td>8.1.0</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip">org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip">org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Mac</td>
         <td>8.1.0</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Linux</td>
         <td>8.1.0</td>
        <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz</a>
         </td>
       </tr>
     </table>
@@ -137,21 +137,21 @@
         <td class="first_col">Windows</td>
         <td>8.0.0</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.0.0/org.openjdk.jmc-8.0.0-win32.win32.x86_64.zip">org.openjdk.jmc-8.0.0-win32.win32.x86_64.zip</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.0.0/org.openjdk.jmc-8.0.0-win32.win32.x86_64.zip">org.openjdk.jmc-8.0.0-win32.win32.x86_64.zip</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Mac</td>
         <td>8.0.0</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.0.0/org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.0.0/org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Linux</td>
         <td>8.0.0</td>
        <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.0.0/org.openjdk.jmc-8.0.0-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.0.0-linux.gtk.x86_64.tar.gz</a>
+          <a href="https://github.com/adoptium/jmc-overrides/releases/download/8.0.0/org.openjdk.jmc-8.0.0-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.0.0-linux.gtk.x86_64.tar.gz</a>
         </td>
       </tr>
     </table>

--- a/src/handlebars/jmc.handlebars
+++ b/src/handlebars/jmc.handlebars
@@ -1,14 +1,14 @@
-{{> header title='JDK Mission Control | ' }}
+{{> header title='Eclipse Mission Control | ' }}
 
 <main class="grey-bg">
 
-<h1 class="margin-bottom large-title">JDK Mission Control</h1>
+<h1 class="margin-bottom large-title">Eclipse Mission Control</h1>
 <div class="info-page-container upstream blue-link-section">
   <div class="download">
-    <p>JDK Mission Control is a low-overhead profiling and diagostics tools suite for the JVM.</p>
-    <p>For a JDK Mission Control introduction, have a look at <a href="https://github.com/thegreystone/jmc-tutorial">Marcus Hirt's tutorial</a>.</p>
+    <p>Eclipse Mission Control is a low-overhead profiling and diagostics tools suite for the JVM.</p>
+    <p>For a Eclipse Mission Control introduction, have a look at <a href="https://github.com/thegreystone/jmc-tutorial">Marcus Hirt's tutorial</a>.</p>
 
-    <h2 class="medium-title">Final JDK Mission Control 8.1.1 (latest stable)</h2>
+    <h2 class="medium-title">Final Eclipse Mission Control 8.1.1 (latest stable)</h2>
     <table id="release">
       <tr>
         <th>System</th>
@@ -40,7 +40,7 @@
 
     <br>
 
-    <h2 class="medium-title">Preview JDK Mission Control 8.2.0 (early access)</h2>
+    <h2 class="medium-title">Preview Eclipse Mission Control 8.2.0 (early access)</h2>
     <table id="release">
       <tr>
         <th>System</th>
@@ -97,7 +97,7 @@
     </table>
     <hr>
     <h1 class="medium-title">Older Releases</h1>
-    <h2 class="medium-title">Final JDK Mission Control 8.1.0</h2>
+    <h2 class="medium-title">Final Eclipse Mission Control 8.1.0</h2>
     <table id="release">
       <tr>
         <th>System</th>
@@ -126,7 +126,7 @@
         </td>
       </tr>
     </table>
-    <h2 class="medium-title">Final JDK Mission Control 8.0.0</h2>
+    <h2 class="medium-title">Final Eclipse Mission Control 8.0.0</h2>
     <table id="release">
       <tr>
         <th>System</th>

--- a/src/handlebars/jmc.handlebars
+++ b/src/handlebars/jmc.handlebars
@@ -1,0 +1,164 @@
+{{> header title='JDK Mission Control | ' }}
+
+<main class="grey-bg">
+
+<h1 class="margin-bottom large-title">JDK Mission Control</h1>
+<div class="info-page-container upstream blue-link-section">
+  <div class="download">
+    <p>JDK Mission Control is a low-overhead profiling and diagostics tools suite for the JVM.</p>
+    <p>For a JDK Mission Control introduction, have a look at <a href="https://github.com/thegreystone/jmc-tutorial">Marcus Hirt's tutorial</a>.</p>
+
+    <h2 class="medium-title">Final JDK Mission Control 8.1.1 (latest stable)</h2>
+    <table id="release">
+      <tr>
+        <th>System</th>
+        <th>Version</th>
+        <th>Download</th>
+      </tr>
+      <tr>
+        <td class="first_col">Windows</td>
+        <td>8.1.1</td>
+        <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.1/org.openjdk.jmc-8.1.1-win32.win32.x86_64.zip">org.openjdk.jmc-8.1.1-win32.win32.x86_64.zip</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="first_col">Mac</td>
+        <td>8.1.1</td>
+        <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.1/org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="first_col">Linux</td>
+        <td>8.1.1</td>
+       <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.1/org.openjdk.jmc-8.1.1-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.1.1-linux.gtk.x86_64.tar.gz</a>
+        </td>
+      </tr>
+    </table>
+
+    <br>
+
+    <h2 class="medium-title">Preview JDK Mission Control 8.2.0 (early access)</h2>
+    <table id="release">
+      <tr>
+        <th>System</th>
+        <th>Version</th>
+        <th>Download</th>
+      </tr>
+      <tr>
+        <td class="first_col">Windows</td>
+        <td>8.2.0-SNAPSHOT</td>
+        <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-win32.win32.x86_64.zip">org.openjdk.jmc-8.2.0-SNAPSHOT-win32.win32.x86_64.zip</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="first_col">Mac</td>
+        <td>8.2.0-SNAPSHOT</td>
+        <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.2.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="first_col">Linux</td>
+        <td>8.2.0-SNAPSHOT</td>
+       <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.2.0-SNAPSHOT-linux.gtk.x86_64.tar.gz</a>
+        </td>
+      </tr>
+    </table>
+
+    <br>
+    <h3 class="medium-title" id="macosx-install">Note (MacOS X)</h3>
+    <p>Please unpack the archive using: <pre>cat org.openjdk.jmc-8.1.1-macosx.cocoa.x86_64.tar.gz |tar xv -</pre> or <pre>cat org.openjdk.jmc-8.2.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz |tar xv -</pre></p>
+
+    <br>
+    <p>We also provide an Eclipse update site archive for installing JMC into the Eclipse IDE:</p>
+
+    <table id="release">
+      <tr>
+        <th>Version</th>
+        <th>Download</th>
+      </tr>
+      <tr>
+        <td>8.1.1</td>
+        <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.1/org.openjdk.jmc.updatesite.ide-8.1.1.zip">org.openjdk.jmc.updatesite.ide-8.1.1.zip</a>
+        </td>
+      </tr>
+      <tr>
+        <td>8.2.0-SNAPSHOT</td>
+        <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc.updatesite.ide-8.2.0-SNAPSHOT.zip">org.openjdk.jmc.updatesite.ide-8.2.0-SNAPSHOT.zip</a>
+        </td>
+      </tr>
+    </table>
+    <hr>
+    <h1 class="medium-title">Older Releases</h1>
+    <h2 class="medium-title">Final JDK Mission Control 8.1.0</h2>
+    <table id="release">
+      <tr>
+        <th>System</th>
+        <th>Version</th>
+        <th>Download</th>
+      </tr>
+      <tr>
+        <td class="first_col">Windows</td>
+        <td>8.1.0</td>
+        <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip">org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="first_col">Mac</td>
+        <td>8.1.0</td>
+        <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="first_col">Linux</td>
+        <td>8.1.0</td>
+       <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz</a>
+        </td>
+      </tr>
+    </table>
+    <h2 class="medium-title">Final JDK Mission Control 8.0.0</h2>
+    <table id="release">
+      <tr>
+        <th>System</th>
+        <th>Version</th>
+        <th>Download</th>
+      </tr>
+      <tr>
+        <td class="first_col">Windows</td>
+        <td>8.0.0</td>
+        <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.0.0/org.openjdk.jmc-8.0.0-win32.win32.x86_64.zip">org.openjdk.jmc-8.0.0-win32.win32.x86_64.zip</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="first_col">Mac</td>
+        <td>8.0.0</td>
+        <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.0.0/org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="first_col">Linux</td>
+        <td>8.0.0</td>
+       <td>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.0.0/org.openjdk.jmc-8.0.0-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.0.0-linux.gtk.x86_64.tar.gz</a>
+        </td>
+      </tr>
+    </table>
+
+  </div>
+</div>
+
+</main>
+
+{{> footer }}

--- a/src/handlebars/partials/menu.handlebars
+++ b/src/handlebars/partials/menu.handlebars
@@ -16,7 +16,7 @@
       <li><a href="./support.html">Support</a></li>
       <li class="submenu"><a>Projects</a>
         <ul>
-          <li><a href="./jmc.html">JDK Mission Control</a></li>
+          <li><a href="./jmc.html">Eclipse Mission Control</a></li>
         </ul>
       </li>
       <li class="submenu"><a>Further information</a>

--- a/src/handlebars/partials/menu.handlebars
+++ b/src/handlebars/partials/menu.handlebars
@@ -14,6 +14,11 @@
       <li><a href="./installation.html">Installation</a></li>
       <li><a href="./migration.html">Migration Guide</a></li>
       <li><a href="./support.html">Support</a></li>
+      <li class="submenu"><a>Projects</a>
+        <ul>
+          <li><a href="./jmc.html">JDK Mission Control</a></li>
+        </ul>
+      </li>
       <li class="submenu"><a>Further information</a>
         <ul>
           <li><a href="./about.html">About</a></li>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

This PR adds a page with downloads for the Adoptium builds of JDK Mission Control. It is a copy of the contents [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/src/handlebars/jmc.handlebars) updated with the latest 8.1.1 release. It is accessible under a Projects submenu, similar to the AdoptOpenJDK site.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
