### PR TITLE
Update banner with January 2022 release status

### DIFF
--- a/src/handlebars/partials/header.handlebars
+++ b/src/handlebars/partials/header.handlebars
@@ -71,17 +71,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </nav>
 
   <!-- Banner Div - This is where you can add banners to the website -->
-  <!--
   <div class="alert align-center">
     <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
 
-    <strong>12th November 2021:</strong> Eclipse Temurin 8u312, 11.0.13 and 17.0.1 are
-    <a style="color: white" href="https://blog.adoptium.net/2021/11/eclipse-temurin-8u312-11013-and-1701-available/">
-    now available</a>. Linux packages coming soon.<br/>
-    Missing the v17 JRE? See our post on
-    <a style="color: white" href="https://blog.adoptium.net/2021/10/jlink-to-produce-own-runtime">
-      creating an equivalent runtime with jlink
-    </a>
+    <strong>18th January 2022:</strong>
+    We are creating the January 2022 PSU binaries for Eclipse Temurin 8u322, 11.0.14 and 17.0.2.<br/>
+    You can follow the status in
+    <a style="color: white" href="https://github.com/adoptium/adoptium/issues/109">this issue</a>.
+    Windows, Linux and MacOS on x64 are being prioritised. 
 
   </div>
-  -->


### PR DESCRIPTION
Note: At the time of writing only 11.0.14 is available and being built. We are still waiting on the 8 and 17 tags.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
