### PR TITLE
Update support page with JDK11.0.14.1+1 release

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -86,8 +86,8 @@
           <td><strong>Java 11 (LTS)</strong></td>
           <td><strong>September 2018</strong></td>
           <td>
-            <strong>jdk-11.0.14+9<br/>
-            18th Jan 2022</strong>
+            <strong>jdk-11.0.14.1+1<br/>
+            8th Feb 2022</strong>
           </td>
           <td>
             <strong>jdk-11.0.15<br/>

--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -73,12 +73,12 @@
           <td><strong>Java 8 (LTS)</strong></td>
           <td><strong>Mar 2014</strong></td>
           <td>
-            <strong>jdk8u312-b07<br/>
-            19th Oct 2021</strong>
+            <strong>jdk8u322-b08<br/>
+            18th Jan 2022</strong>
           </td>
           <td>
-            <strong>jdk8u322<br/>
-            18th Jan 2022</strong>
+            <strong>jdk8u332<br/>
+            19th Apr 2022</strong>
           </td>
           <td><strong>At Least May 2026 <sup>[1]</sup></strong></td>
         </tr>
@@ -86,12 +86,12 @@
           <td><strong>Java 11 (LTS)</strong></td>
           <td><strong>September 2018</strong></td>
           <td>
-            <strong>jdk-11.0.13+8<br/>
-            19th Oct 2021</strong>
+            <strong>jdk-11.0.14+9<br/>
+            18th Jan 2022</strong>
           </td>
           <td>
-            <strong>jdk-11.0.14<br/>
-            18th Jan 2022</strong>
+            <strong>jdk-11.0.15<br/>
+            19th Apr 2022</strong>
           </td>
           <td><strong>At Least Oct 2024 <sup>[1]</sup></strong></td>
         </tr>
@@ -109,12 +109,12 @@
           <td><strong>Java 17 (LTS)<strong></td>
           <td><strong>Sep 2021</strong></td>
           <td>
-            <strong>jdk-17.0.1+12<br/>
-                    19th Oct 2021</strong>
+            <strong>jdk-17.0.2+8<br/>
+                    18th Jan 2022</strong>
           </td>
           <td>
-            <strong>jdk-17.0.2<br/>
-            18th Jan 2022</strong>
+            <strong>jdk-17.0.3<br/>
+            19th Apr 2022</strong>
           </td>
           <td>TBC<sup>[1]</sup></td>
         </tr>


### PR DESCRIPTION
Self-explanatory and trivial - this is the release from the upstream https://github.com/openjdk/jdk11u/releases/tag/jdk-11.0.14.1-ga tag :-)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
