### PR TITLE
Update banner to mentioned 11.0.14.1 regression fix

### DIFF
--- a/src/handlebars/partials/header.handlebars
+++ b/src/handlebars/partials/header.handlebars
@@ -74,9 +74,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <div class="alert align-center">
     <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
 
-    <strong>31st January 2022:</strong>
-    The January 2022 PSU of Eclipse Temurin 8u322, 11.0.14 and 17.0.2 are now available for most platforms with just a few left to complete.<br/>
-    Linux packages and docker images will be available soon. You can follow the status in
-    <a style="color: white" href="https://github.com/adoptium/adoptium/issues/109">this issue</a>.
+    <strong>11th February 2022:</strong>
+    If you have recently picked up the jdk-11.0.14+9 release, please update to jdk-11.0.14.1+1 to pick up
+    <a style="color: white" href="https://github.com/adoptium/jdk11u/commit/ef5fff53ef1b047c2fca47047fe743689cc2734f">
+    a fix for a regression in the HTTPClient code</a>.
 
   </div>


### PR DESCRIPTION
Remove information about January releases being in progress and mention that 11.0.14+9 has a regression which has now been fixed via a re-release.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
