### PR TITLE
Update expected release date for JDK18

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -119,7 +119,7 @@
           <td>N/A</td>
           <td>
             jdk-18<br/>
-            15th Mar 2022
+            22nd Mar 2022
           </td>
           <td>Sep 2022</td>
         </tr>


### PR DESCRIPTION
This one won't be the closest Tuesday to the 17th of March, according to the following sources:

- https://openjdk.java.net/projects/jdk/18/
- https://www.java.com/releases/

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/master/CONTRIBUTING.md)
